### PR TITLE
feat(PSW-02-04): finish charts in a dashboard page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -79,7 +79,7 @@
 .dark {
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
+  --card: oklch(0.141 0.005 285.823);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.21 0.006 285.885);
   --popover-foreground: oklch(0.985 0 0);

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,13 @@
+import { Link } from "react-router-dom";
+
+export function NotFound() {
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-2">
+      <h1 className="text-4xl font-bold">Página não encontrada</h1>
+      <p className="text-accent-foreground">
+        Voltar para o <Link to="/" className="text-sky-600 dark:text-sky-400">Dashboard</Link>
+      </p>
+    </div>
+  )
+}

--- a/src/pages/app/dashboard/dashboard.tsx
+++ b/src/pages/app/dashboard/dashboard.tsx
@@ -4,6 +4,7 @@ import { MonthOrdersAmountCard } from "./month-orders-amount-card"
 import { DayOrdersAmountCard } from "./day-orders-amount-card"
 import { MonthCanceledOrdersAmountCard } from "./month-canceled-amount-card"
 import { RevenueChart } from "./revenue-chart"
+import { PopularProductsChart } from "./popular-chart"
 
 export function Dashboard() {
 
@@ -22,6 +23,7 @@ export function Dashboard() {
 
         <div className="grid grid-cols-9 gap-4">
           <RevenueChart />
+          <PopularProductsChart />
         </div>
       </div>
     </>

--- a/src/pages/app/dashboard/popular-chart.tsx
+++ b/src/pages/app/dashboard/popular-chart.tsx
@@ -1,0 +1,89 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BarChart } from "lucide-react";
+import { ResponsiveContainer, Pie, PieChart, Cell } from 'recharts'
+import colors from 'tailwindcss/colors'
+
+const data = [
+  { product: 'Pepperoni', amount: 40 },
+  { product: 'Mussarela', amount: 30 },
+  { product: 'Marguerita', amount: 50 },
+  { product: '4 queijos', amount: 16 },
+  { product: 'CatuBacon', amount: 26 },
+]
+
+const COLORS = [
+  colors.sky['500'],
+  colors.amber['500'],
+  colors.violet['500'],
+  colors.emerald['500'],
+  colors.rose['500']
+]
+
+export function PopularProductsChart() {
+  return (
+    <Card className="col-span-3">
+      <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base font-medium">Produtos populares</CardTitle>
+            <BarChart className="h-4 w-4 text-muted-foreground" />
+          </div>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={240}>
+          <PieChart style={{ fontSize: 12 }}>
+            <Pie 
+              data={data} 
+              dataKey="amount"
+              nameKey="product"
+              cx="50%" cy="50%"
+              outerRadius={86}
+              innerRadius={64}
+              strokeWidth={8}
+              labelLine={false}
+              label={({
+                cx,
+                cy,
+                midAngle,
+                innerRadius,
+                outerRadius,
+                value,
+                index,
+              }) => {
+                const RADIAN = Math.PI / 180
+                const radius = 12 + innerRadius + (outerRadius - innerRadius)
+                // @ts-expect-error
+                const x = cx + radius * Math.cos(-midAngle * RADIAN)
+                // @ts-expect-error
+                const y = cy + radius * Math.sin(-midAngle * RADIAN)
+
+                return (
+                  <text
+                    x={x}
+                    y={y}
+                    className="fill-muted-foreground text-xs"
+                    textAnchor={x > cx ? 'start' : 'end'}
+                    dominantBaseline="central"
+                  >
+                    {// @ts-expect-error
+                      data[index].product.length > 12
+                        // @ts-expect-error
+                        ? data[index].product.substring(0, 12).concat('...')
+                        // @ts-expect-error
+                        : data[index].product}{' '}
+                    ({value})
+                  </text>
+                )
+              }}
+            >
+              {data.map((_, index) => {
+                return (
+                  <Cell key={`cell-${index}`} fill={COLORS[index]} className="stroke-background hover:opacity-80"></Cell>
+                )
+              })}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/pages/app/dashboard/revenue-chart.tsx
+++ b/src/pages/app/dashboard/revenue-chart.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { ResponsiveContainer, LineChart, XAxis, YAxis, CartesianGrid, Line, Tooltip } from 'recharts'
+import { ResponsiveContainer, LineChart, XAxis, YAxis, CartesianGrid, Line } from 'recharts'
 import colors from 'tailwindcss/colors'
 
 const data = [
@@ -27,6 +27,11 @@ export function RevenueChart() {
             <XAxis dataKey="date" tickLine={false} axisLine={false} dy={16} />
             <YAxis stroke="#888" axisLine={false} tickLine={false} width={80} tickFormatter={(value: number) => value.toLocaleString('pt-BR', {style: 'currency', currency: 'BRL'})} />
             <Line type="linear" strokeWidth={2} dataKey="revenue" stroke={colors['violet']['500']}/>
+
+            <CartesianGrid
+              className="stroke-muted"
+              vertical={false}
+            />
           </LineChart>
         </ResponsiveContainer>
       </CardContent>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,12 +6,14 @@ import { AppLayout } from './pages/_layouts/app'
 import { AuthLayout } from './pages/_layouts/auth'
 import { SignUp } from './pages/auth/sign-up'
 import { Orders } from './pages/app/orders/orders'
+import { NotFound } from './pages/404'
 
 export const router = createBrowserRouter([
 
   {
     path: '/',
     element: <AppLayout />,
+    errorElement: <NotFound />,
     children: [
       {path: "/", element: <Dashboard /> },
       {path: "/orders", element: <Orders /> }


### PR DESCRIPTION
Finish the charts in the dashboard page, including the popular products chart and the revenue chart. Also, add a 404 page for handling non-existent routes.

Obs: The Card components had wrong background colors, and I fixed them in a class base file and add Cartesian Grid in the charts for better visualization and put messages to ignore verification about ts stuffs on popular-chart component.